### PR TITLE
Fix displayed language in category filter view

### DIFF
--- a/Harrastuspassi/Views/TableViews/TableViewCells/CategoryFilterTableViewCell.swift
+++ b/Harrastuspassi/Views/TableViews/TableViewCells/CategoryFilterTableViewCell.swift
@@ -34,8 +34,7 @@ class CategoryFilterTableViewCell: UITableViewCell {
     }
     
     func setTitle(category: CategoryData) -> String? {
-        let lang = Locale.preferredLanguages.first;
-        print(lang)
+        let lang = Locale.current.languageCode;
         switch lang {
         case "fi":
             return category.nameFI;


### PR DESCRIPTION
Hobby category names are in same language than device